### PR TITLE
Swap batch for waitgroup

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "segment.js",
   "dependencies": {
     "aws-sdk": "^2.1.42",
-    "batch": "^0.5.2",
+    "waitgroup": "^1.1.0",
     "date-math": "0.0.1",
     "multipipe": "^0.1.2",
     "split": "^1.0.0",


### PR DESCRIPTION
`Batch` doesnt execute queued work until `.end` is called, effectively nullifying any advantage to streaming the data in the first place.

By switching to waitgroup semantics, we can just maintain a counter of ongoing async operations, and exit when all have finished.

@calvinfo mind taking a look? thanks!

**the real question**: lambda, y u no golang?
